### PR TITLE
Add asyncBoundary to res controller

### DIFF
--- a/back-end/src/reservations/reservations.controller.js
+++ b/back-end/src/reservations/reservations.controller.js
@@ -228,7 +228,7 @@ module.exports = {
     asyncErrorBoundary(isValidId),
     statusNotUnknown,
     statusNotFinished,
-    updateStatus,
+    asyncErrorBoundary(updateStatus),
   ],
   updateReservation: [
     asyncErrorBoundary(isValidId),
@@ -239,6 +239,6 @@ module.exports = {
     bodyDataHas("reservation_time"),
     hasValidProperties,
     hasValidPropertyValue,
-    updateReservation,
+    asyncErrorBoundary(updateReservation),
   ],
 };


### PR DESCRIPTION
added asyncErrorBoundary to "updateStatus" and "updateReservation" requests that were missing the provided try/catch functionality in reservations.controller.js